### PR TITLE
[FIX] scroll and dark mode

### DIFF
--- a/src/components/DarkMode.js
+++ b/src/components/DarkMode.js
@@ -5,24 +5,19 @@ import lightmode from '../assets/light.png';
 
 
 function DarkMode() {
-	const [darkMode, setDarkMode] = useState(false);
   const [img, setImg] = useState(darkmode);
 
-	function changeMode() {
-		if(darkMode) {
-			document.body.classList.add('dark-mode-colors');
-      setImg(lightmode);
-		} else {
-			document.body.classList.remove('dark-mode-colors');
-      setImg(darkmode);
-		}
-	}
+  const handlerDarkMode = () => {
+    const body = document.body
+    const isDarkMode = body.classList.contains('dark-mode-colors')
+    setImg(
+      isDarkMode ?darkmode :lightmode
+    )
+    body.classList.toggle('dark-mode-colors');
+  }
 
 	return (
-		<div onClick={() => {
-			setDarkMode(!darkMode);
-			changeMode();
-		}} className="dark__mode">
+		<div onClick={handlerDarkMode} className="dark__mode">
 			<img className="dark__mode-icon" src={img} alt="dark mode icon" />
 		</div>
 	)

--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,6 @@ a:hover {
   margin: 2em auto;
   width: 100%;
   max-width: 100vh;
-  overflow: scroll;
   max-width: 1024px;
 }
 
@@ -178,6 +177,8 @@ a:hover {
   position: fixed;
   bottom: 10px;
   right: 10px;
+  border-radius: 50%;
+  overflow: hidden;
   cursor: pointer;
 }
 


### PR DESCRIPTION
scroll: Propiedad `overflow: scroll` eliminada de la clase `.App`.
dark mode:  Tenía un detalle en el cual necesitaba hacer doble click la primera vez para poder cambiar el tema.